### PR TITLE
Add a slider for `Transmissivity cap` value

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -352,7 +352,7 @@ public class PathTracer implements RayTracer {
 
                 if (pathTrace(scene, refracted, state, 1, false)) {
                   // Calculate the color and emittance of the refracted ray
-                  translucentRayColor(ray, refracted, pDiffuse);
+                  translucentRayColor(scene, ray, refracted, pDiffuse);
                   hit = true;
                 }
               }
@@ -367,7 +367,7 @@ public class PathTracer implements RayTracer {
 
           if (pathTrace(scene, transmitted, state, 1, false)) {
             // Calculate the color and emittance of the transmitted ray
-            translucentRayColor(ray, transmitted, pDiffuse);
+            translucentRayColor(scene, ray, transmitted, pDiffuse);
             hit = true;
           }
         }
@@ -441,7 +441,7 @@ public class PathTracer implements RayTracer {
     return hit;
   }
 
-  private static void translucentRayColor(Ray ray, Ray next, double opacity) {
+  private static void translucentRayColor(Scene scene, Ray ray, Ray next, double opacity) {
     // Color-based transmission value
     double colorTrans = (ray.color.x + ray.color.y + ray.color.z)/3;
     // Total amount of light we want to transmit (overall transparency of texture)
@@ -455,28 +455,28 @@ public class PathTracer implements RayTracer {
       bTrans = ray.color.z * shouldTrans / colorTrans;
     }
     // TODO: Make this controllable from 1 to 3 via a slider
-    final double TRANSMISSIVITY_CAP = 1;
+    double transmissivityCap = scene.transmissivityCap;
     // Determine the color with the highest transmissivity
     double maxTrans = Math.max(rTrans, Math.max(gTrans, bTrans));
-    if(maxTrans > TRANSMISSIVITY_CAP) {
+    if(maxTrans > transmissivityCap) {
       if (maxTrans == rTrans) {
         // Give excess transmission from red to green and blue
-        double gTransNew = reassignTransmissivity(rTrans, gTrans, bTrans, shouldTrans, TRANSMISSIVITY_CAP);
-        bTrans = reassignTransmissivity(rTrans, bTrans, gTrans, shouldTrans, TRANSMISSIVITY_CAP);
+        double gTransNew = reassignTransmissivity(rTrans, gTrans, bTrans, shouldTrans, transmissivityCap);
+        bTrans = reassignTransmissivity(rTrans, bTrans, gTrans, shouldTrans, transmissivityCap);
         gTrans = gTransNew;
-        rTrans = TRANSMISSIVITY_CAP;
+        rTrans = transmissivityCap;
       } else if (maxTrans == gTrans) {
         // Give excess transmission from green to red and blue
-        double rTransNew = reassignTransmissivity(gTrans, rTrans, bTrans, shouldTrans, TRANSMISSIVITY_CAP);
-        bTrans = reassignTransmissivity(gTrans, bTrans, rTrans, shouldTrans, TRANSMISSIVITY_CAP);
+        double rTransNew = reassignTransmissivity(gTrans, rTrans, bTrans, shouldTrans, transmissivityCap);
+        bTrans = reassignTransmissivity(gTrans, bTrans, rTrans, shouldTrans, transmissivityCap);
         rTrans = rTransNew;
-        gTrans = TRANSMISSIVITY_CAP;
+        gTrans = transmissivityCap;
       } else if (maxTrans == bTrans) {
         // Give excess transmission from blue to green and red
-        double gTransNew = reassignTransmissivity(bTrans, gTrans, rTrans, shouldTrans, TRANSMISSIVITY_CAP);
-        rTrans = reassignTransmissivity(bTrans, rTrans, gTrans, shouldTrans, TRANSMISSIVITY_CAP);
+        double gTransNew = reassignTransmissivity(bTrans, gTrans, rTrans, shouldTrans, transmissivityCap);
+        rTrans = reassignTransmissivity(bTrans, rTrans, gTrans, shouldTrans, transmissivityCap);
         gTrans = gTransNew;
-        bTrans = TRANSMISSIVITY_CAP;
+        bTrans = transmissivityCap;
       }
     }
     // Set transparent and opaque components of each color channel

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -133,7 +133,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Default transmissivity cap.
    */
-  public static final double DEFAULT_TRANSMISSIVITY_CAP = 1.5;
+  public static final double DEFAULT_TRANSMISSIVITY_CAP = 1;
 
   /**
    * Minimum transmissivity cap.

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -131,6 +131,21 @@ public class Scene implements JsonSerializable, Refreshable {
   public static final double MAX_EMITTER_INTENSITY = 1000;
 
   /**
+   * Default transmissivity cap.
+   */
+  public static final double DEFAULT_TRANSMISSIVITY_CAP = 1.5;
+
+  /**
+   * Minimum transmissivity cap.
+   */
+  public static final double MIN_TRANSMISSIVITY_CAP = 1;
+
+  /**
+   * Maximum transmissivity cap.
+   */
+  public static final double MAX_TRANSMISSIVITY_CAP = 3;
+
+  /**
    * Default exposure.
    */
   public static final double DEFAULT_EXPOSURE = 1.0;
@@ -194,6 +209,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean emittersEnabled = DEFAULT_EMITTERS_ENABLED;
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
   protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
+  protected double transmissivityCap = DEFAULT_TRANSMISSIVITY_CAP;
 
   protected SunSamplingStrategy sunSamplingStrategy = SunSamplingStrategy.FAST;
 
@@ -468,6 +484,7 @@ public class Scene implements JsonSerializable, Refreshable {
     emitterIntensity = other.emitterIntensity;
     emitterSamplingStrategy = other.emitterSamplingStrategy;
     preventNormalEmitterWithSampling = other.preventNormalEmitterWithSampling;
+    transmissivityCap = other.transmissivityCap;
     transparentSky = other.transparentSky;
     fogDensity = other.fogDensity;
     skyFogDensity = other.skyFogDensity;
@@ -2666,6 +2683,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("saveSnapshots", saveSnapshots);
     json.add("emittersEnabled", emittersEnabled);
     json.add("emitterIntensity", emitterIntensity);
+    json.add("transmissivityCap", transmissivityCap);
     json.add("sunSamplingStrategy", sunSamplingStrategy.getId());
     json.add("stillWater", stillWater);
     json.add("waterOpacity", waterOpacity);
@@ -2951,6 +2969,7 @@ public class Scene implements JsonSerializable, Refreshable {
     saveSnapshots = json.get("saveSnapshots").boolValue(saveSnapshots);
     emittersEnabled = json.get("emittersEnabled").boolValue(emittersEnabled);
     emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
+    transmissivityCap = json.get("transmissivityCap").doubleValue(transmissivityCap);
 
     if (json.get("sunSamplingStrategy").isUnknown()) {
       boolean sunSampling = json.get("sunEnabled").boolValue(false);
@@ -3505,5 +3524,14 @@ public class Scene implements JsonSerializable, Refreshable {
 
   public void setHideUnknownBlocks(boolean hideUnknownBlocks) {
     this.hideUnknownBlocks = hideUnknownBlocks;
+  }
+
+  public double getTransmissivityCap() {
+    return transmissivityCap;
+  }
+
+  public void setTransmissivityCap(double value) {
+    transmissivityCap = value;
+    refresh();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -63,6 +63,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private Button mergeRenderDump;
   @FXML private CheckBox shutdown;
   @FXML private CheckBox fastFog;
+  @FXML private DoubleAdjuster transmissivityCap;
   @FXML private IntegerAdjuster cacheResolution;
   @FXML private DoubleAdjuster animationTime;
   @FXML private ChoiceBox<PictureExportFormat> outputMode;
@@ -132,6 +133,11 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     fastFog.setTooltip(new Tooltip("Enable faster fog rendering algorithm."));
     fastFog.selectedProperty()
             .addListener((observable, oldValue, newValue) -> scene.setFastFog(newValue));
+    transmissivityCap.setName("Transmissivity cap");
+    transmissivityCap.setRange(Scene.MIN_TRANSMISSIVITY_CAP, Scene.MAX_TRANSMISSIVITY_CAP);
+    transmissivityCap.clampBoth();
+    transmissivityCap.setTooltip("Maximum amplification of one color channel as a ray passes through a translucent block (stained glass, ice, etc.).\nA value of 1 prevents amplification entirely; higher values result in more vibrant colors.");
+    transmissivityCap.onValueChange(value -> scene.setTransmissivityCap(value));
     cacheResolution.setName("Sky cache resolution");
     cacheResolution.setTooltip("Resolution of the sky cache. Lower values will use less memory and improve performance but can cause sky artifacts.");
     cacheResolution.setRange(1, 4096);
@@ -276,6 +282,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   public void update(Scene scene) {
     outputMode.getSelectionModel().select(scene.getOutputMode());
     fastFog.setSelected(scene.fastFog());
+    transmissivityCap.set(scene.getTransmissivityCap());
     renderThreads.set(PersistentSettings.getNumThreads());
     cpuLoad.set(PersistentSettings.getCPULoad());
     rayDepth.set(scene.getRayDepth());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
@@ -47,7 +47,6 @@ import java.util.ResourceBundle;
 public class MaterialsTab extends ScrollPane implements RenderControlsTab, Initializable {
   private Scene scene;
 
-  private final DoubleAdjuster transmissivityCap = new DoubleAdjuster();
   private final DoubleAdjuster emittance = new DoubleAdjuster();
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
@@ -56,12 +55,6 @@ public class MaterialsTab extends ScrollPane implements RenderControlsTab, Initi
   private final ListView<String> listView;
 
   public MaterialsTab() {
-    transmissivityCap.setName("Transmissivity cap");
-    transmissivityCap.setRange(Scene.MIN_TRANSMISSIVITY_CAP, Scene.MAX_TRANSMISSIVITY_CAP);
-    transmissivityCap.clampBoth();
-    transmissivityCap.setTooltip("Maximum amplification of one color channel as a ray passes through a translucent block (stained glass, ice, etc.).\nA value of 1 prevents amplification entirely; higher values result in more vibrant colors.");
-    transmissivityCap.onValueChange(value -> scene.setTransmissivityCap(value));
-
     emittance.setName("Emittance");
     emittance.setRange(0, 100);
     emittance.setTooltip("Intensity of the light emitted from the selected material.");
@@ -81,12 +74,6 @@ public class MaterialsTab extends ScrollPane implements RenderControlsTab, Initi
     metalness.setName("Metalness");
     metalness.setRange(0, 1);
     metalness.setTooltip("Metalness (texture-tinted reflectivity) of the selected material.");
-
-    Label globalMaterialPropertiesLabel = new Label("Global Material Properties");
-    globalMaterialPropertiesLabel.getStyleClass().add("group-label");
-
-    VBox globalMaterialPropertiesBox = new VBox(10.0);
-    globalMaterialPropertiesBox.getChildren().addAll(globalMaterialPropertiesLabel, transmissivityCap);
 
     ObservableList<String> blockIds = FXCollections.observableArrayList();
     blockIds.addAll(MaterialStore.collections.keySet());
@@ -128,11 +115,8 @@ public class MaterialsTab extends ScrollPane implements RenderControlsTab, Initi
     HBox materialPropertiesBox = new HBox(15.0);
     materialPropertiesBox.getChildren().addAll(listPane, settings);
 
-    VBox mainBox = new VBox(10.0);
-    mainBox.getChildren().addAll(globalMaterialPropertiesBox, new Separator(), materialPropertiesBox);
-
     setPadding(new Insets(10));
-    setContent(mainBox);
+    setContent(materialPropertiesBox);
   }
 
   private void updateSelectedMaterial(String materialName) {
@@ -195,7 +179,6 @@ public class MaterialsTab extends ScrollPane implements RenderControlsTab, Initi
   @Override public void update(Scene scene) {
     String material = listView.getSelectionModel().getSelectedItem();
     updateSelectedMaterial(material);
-    transmissivityCap.set(scene.getTransmissivityCap());
   }
 
   @Override public String getTabTitle() {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
@@ -25,9 +25,7 @@ import javafx.fxml.Initializable;
 import javafx.geometry.Insets;
 import javafx.geometry.Pos;
 import javafx.scene.Node;
-import javafx.scene.control.Label;
-import javafx.scene.control.ListView;
-import javafx.scene.control.TextField;
+import javafx.scene.control.*;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import se.llbit.chunky.block.*;
@@ -46,9 +44,10 @@ import java.util.Comparator;
 import java.util.ResourceBundle;
 
 // TODO: customization of textures, base color, etc.
-public class MaterialsTab extends HBox implements RenderControlsTab, Initializable {
+public class MaterialsTab extends ScrollPane implements RenderControlsTab, Initializable {
   private Scene scene;
 
+  private final DoubleAdjuster transmissivityCap = new DoubleAdjuster();
   private final DoubleAdjuster emittance = new DoubleAdjuster();
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
@@ -57,25 +56,43 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   private final ListView<String> listView;
 
   public MaterialsTab() {
+    transmissivityCap.setName("Transmissivity cap");
+    transmissivityCap.setRange(Scene.MIN_TRANSMISSIVITY_CAP, Scene.MAX_TRANSMISSIVITY_CAP);
+    transmissivityCap.clampBoth();
+    transmissivityCap.setTooltip("Maximum amplification of one color channel as a ray passes through a translucent block (stained glass, ice, etc.).\nA value of 1 prevents amplification entirely; higher values result in more vibrant colors.");
+    transmissivityCap.onValueChange(value -> scene.setTransmissivityCap(value));
+
     emittance.setName("Emittance");
     emittance.setRange(0, 100);
     emittance.setTooltip("Intensity of the light emitted from the selected material.");
+
     specular.setName("Specular");
     specular.setRange(0, 1);
     specular.setTooltip("Reflectivity of the selected material.");
+
     ior.setName("IoR");
     ior.setRange(0, 5);
     ior.setTooltip("Index of Refraction of the selected material.");
+
     perceptualSmoothness.setName("Smoothness");
     perceptualSmoothness.setRange(0, 1);
     perceptualSmoothness.setTooltip("Smoothness of the selected material.");
+
     metalness.setName("Metalness");
     metalness.setRange(0, 1);
     metalness.setTooltip("Metalness (texture-tinted reflectivity) of the selected material.");
+
+    Label globalMaterialPropertiesLabel = new Label("Global Material Properties");
+    globalMaterialPropertiesLabel.getStyleClass().add("group-label");
+
+    VBox globalMaterialPropertiesBox = new VBox(10.0);
+    globalMaterialPropertiesBox.getChildren().addAll(globalMaterialPropertiesLabel, transmissivityCap);
+
     ObservableList<String> blockIds = FXCollections.observableArrayList();
     blockIds.addAll(MaterialStore.collections.keySet());
     blockIds.addAll(ExtraMaterials.idMap.keySet());
     blockIds.addAll(MaterialStore.blockIds);
+
     FilteredList<String> filteredList = new FilteredList<>(
       new SortedList<>(blockIds, Comparator.naturalOrder())
     );
@@ -83,14 +100,15 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     listView.getSelectionModel().selectedItemProperty().addListener(
         (observable, oldValue, materialName) -> updateSelectedMaterial(materialName)
     );
-    VBox settings = new VBox();
-    settings.setSpacing(10);
+
+    Label materialPropertiesLabel = new Label("Material Properties");
+    materialPropertiesLabel.getStyleClass().add("group-label");
+    VBox settings = new VBox(10.0);
     settings.getChildren().addAll(
-        new Label("Material Properties"),
+        materialPropertiesLabel,
         emittance, specular, perceptualSmoothness, ior, metalness,
         new Label("(set to zero to disable)"));
-    setPadding(new Insets(10));
-    setSpacing(15);
+
     TextField filterField = new TextField();
     filterField.textProperty().addListener((observable, oldValue, newValue) -> {
       if (newValue.trim().isEmpty()) {
@@ -99,14 +117,22 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
         filteredList.setPredicate(name -> name.contains(newValue));
       }
     });
-    HBox filterBox = new HBox();
+
+    HBox filterBox = new HBox(10.0);
     filterBox.setAlignment(Pos.BASELINE_LEFT);
-    filterBox.setSpacing(10);
     filterBox.getChildren().addAll(new Label("Filter:"), filterField);
-    VBox listPane = new VBox();
-    listPane.setSpacing(10);
+
+    VBox listPane = new VBox(10.0);
     listPane.getChildren().addAll(filterBox, listView);
-    getChildren().addAll(listPane, settings);
+
+    HBox materialPropertiesBox = new HBox(15.0);
+    materialPropertiesBox.getChildren().addAll(listPane, settings);
+
+    VBox mainBox = new VBox(10.0);
+    mainBox.getChildren().addAll(globalMaterialPropertiesBox, new Separator(), materialPropertiesBox);
+
+    setPadding(new Insets(10));
+    setContent(mainBox);
   }
 
   private void updateSelectedMaterial(String materialName) {
@@ -169,6 +195,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   @Override public void update(Scene scene) {
     String material = listView.getSelectionModel().getSelectedItem();
     updateSelectedMaterial(material);
+    transmissivityCap.set(scene.getTransmissivityCap());
   }
 
   @Override public String getTabTitle() {

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
@@ -23,6 +23,7 @@
     <Separator prefWidth="200.0" />
     <CheckBox fx:id="shutdown" mnemonicParsing="false" text="Shutdown computer when render completes" />
     <CheckBox fx:id="fastFog" mnemonicParsing="false" text="Fast fog" />
+    <DoubleAdjuster fx:id="transmissivityCap" />
     <IntegerAdjuster fx:id="cacheResolution" />
     <DoubleAdjuster fx:id="animationTime" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/GeneralTab.fxml
@@ -13,7 +13,7 @@
     <Separator />
     <HBox alignment="CENTER_LEFT" spacing="16">
       <VBox spacing="4">
-        <Label fx:id="canvasSizeLabel" text="Canvas size:" style="-fx-font-weight: bold;"/>
+        <Label fx:id="canvasSizeLabel" text="Canvas size:" styleClass="group-label"/>
         <padding>
           <Insets left="8"/>
         </padding>

--- a/chunky/src/res/style.css
+++ b/chunky/src/res/style.css
@@ -31,6 +31,12 @@ Label {
     -fx-text-fill: #faebd7;
 }
 
+Label.group-label {
+    -fx-text-fill: #faebd7;
+    -fx-font-weight: bold;
+    -fx-font-size: 12px;
+}
+
 Text {
     -fx-fill: #faebd7;
 }


### PR DESCRIPTION
The range of the slider is [1, 3], and its value is clamped to that range. The default value is *1.0*.
The slider is located in the `Advanced` tab.

**New:**
![image](https://user-images.githubusercontent.com/92183530/209860120-c16f01ca-ae85-4cb8-bbe7-a62d83627464.png)
