### PR TITLE
Apparent emitter brightness

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -160,8 +160,6 @@ public class PathTracer implements RayTracer {
         if (random.nextFloat() < pDiffuse) {
           // Diffuse reflection.
 
-          //firstReflection = false;
-
           if (!scene.kill(ray.depth + 1, random)) {
             Ray reflected = new Ray();
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -160,6 +160,9 @@ public class PathTracer implements RayTracer {
         if (random.nextFloat() < pDiffuse) {
           // Diffuse reflection.
 
+          boolean wasFirstReflection = firstReflection;
+          firstReflection = false;
+
           if (!scene.kill(ray.depth + 1, random)) {
             Ray reflected = new Ray();
 
@@ -167,7 +170,7 @@ public class PathTracer implements RayTracer {
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              if (firstReflection) {
+              if (wasFirstReflection) {
                 ray.apparentBrightness.x = ray.color.x * ray.color.x * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;
                 ray.apparentBrightness.y = ray.color.y * ray.color.y * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;
                 ray.apparentBrightness.z = ray.color.z * ray.color.z * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -170,17 +170,17 @@ public class PathTracer implements RayTracer {
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
               if (firstReflection) {
-                ray.apparentBrightness.x = ray.color.x * ray.color.x * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
-                ray.apparentBrightness.y = ray.color.y * ray.color.y * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
-                ray.apparentBrightness.z = ray.color.z * ray.color.z * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+                ray.apparentBrightness.x = ray.color.x * ray.color.x * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;
+                ray.apparentBrightness.y = ray.color.y * ray.color.y * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;
+                ray.apparentBrightness.z = ray.color.z * ray.color.z * currentMat.apparentBrightness * scene.apparentEmitterBrightness * scene.emitterIntensity;
 
               } else {
                 ray.emittance.x = ray.color.x * ray.color.x *
-                  currentMat.emittance * scene.emitterIntensity;
+                  currentMat.emittance * scene.emitterLightIntensity * scene.emitterIntensity;
                 ray.emittance.y = ray.color.y * ray.color.y *
-                  currentMat.emittance * scene.emitterIntensity;
+                  currentMat.emittance * scene.emitterLightIntensity * scene.emitterIntensity;
                 ray.emittance.z = ray.color.z * ray.color.z *
-                  currentMat.emittance * scene.emitterIntensity;
+                  currentMat.emittance * scene.emitterLightIntensity * scene.emitterIntensity;
               }
 
               hit = true;
@@ -476,6 +476,7 @@ public class PathTracer implements RayTracer {
         e *= pos.block.surfaceArea(face);
         e *= emitterRay.getCurrentMaterial().emittance;
         e *= scene.emitterIntensity;
+        e *= scene.emitterLightIntensity;
         e *= scaler;
 
         result.scaleAdd(e, emitterRay.color);

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -170,9 +170,9 @@ public class PathTracer implements RayTracer {
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
               if (firstReflection) {
-                ray.apparentBrightness.x = ray.color.x * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
-                ray.apparentBrightness.y = ray.color.y * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
-                ray.apparentBrightness.z = ray.color.z * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+                ray.apparentBrightness.x = ray.color.x * ray.color.x * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+                ray.apparentBrightness.y = ray.color.y * ray.color.y * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+                ray.apparentBrightness.z = ray.color.z * ray.color.z * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
 
               } else {
                 ray.emittance.x = ray.color.x * ray.color.x *

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -160,7 +160,7 @@ public class PathTracer implements RayTracer {
         if (random.nextFloat() < pDiffuse) {
           // Diffuse reflection.
 
-          firstReflection = false;
+          //firstReflection = false;
 
           if (!scene.kill(ray.depth + 1, random)) {
             Ray reflected = new Ray();
@@ -169,12 +169,20 @@ public class PathTracer implements RayTracer {
 
             if (scene.emittersEnabled && (!scene.isPreventNormalEmitterWithSampling() || scene.getEmitterSamplingStrategy() == EmitterSamplingStrategy.NONE || ray.depth == 0) && currentMat.emittance > Ray.EPSILON) {
 
-              ray.emittance.x = ray.color.x * ray.color.x *
+              if (firstReflection) {
+                ray.apparentBrightness.x = ray.color.x * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+                ray.apparentBrightness.y = ray.color.y * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+                ray.apparentBrightness.z = ray.color.z * currentMat.apparentBrightness * scene.apparentEmitterBrightness;
+
+              } else {
+                ray.emittance.x = ray.color.x * ray.color.x *
                   currentMat.emittance * scene.emitterIntensity;
-              ray.emittance.y = ray.color.y * ray.color.y *
+                ray.emittance.y = ray.color.y * ray.color.y *
                   currentMat.emittance * scene.emitterIntensity;
-              ray.emittance.z = ray.color.z * ray.color.z *
+                ray.emittance.z = ray.color.z * ray.color.z *
                   currentMat.emittance * scene.emitterIntensity;
+              }
+
               hit = true;
             } else if(scene.emittersEnabled && scene.emitterSamplingStrategy != EmitterSamplingStrategy.NONE && scene.getEmitterGrid() != null) {
               // Sample emitter
@@ -232,11 +240,11 @@ public class PathTracer implements RayTracer {
               reflected.diffuseReflection(ray, random);
               hit = pathTrace(scene, reflected, state, 0, false) || hit;
               if (hit) {
-                ray.color.x = (addEmitted * ray.emittance.x) + ray.color.x * (directLightR * scene.sun.emittance.x + (
+                ray.color.x = (addEmitted * ray.apparentBrightness.x) + (addEmitted * ray.emittance.x) + ray.color.x * (directLightR * scene.sun.emittance.x + (
                     reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
-                ray.color.y = (addEmitted * ray.emittance.y) + ray.color.y * (directLightG * scene.sun.emittance.y + (
+                ray.color.y = (addEmitted * ray.apparentBrightness.y) + (addEmitted * ray.emittance.y) + ray.color.y * (directLightG * scene.sun.emittance.y + (
                     reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
-                ray.color.z = (addEmitted * ray.emittance.z) + ray.color.z * (directLightB * scene.sun.emittance.z + (
+                ray.color.z = (addEmitted * ray.apparentBrightness.z) + (addEmitted * ray.emittance.z) + ray.color.z * (directLightB * scene.sun.emittance.z + (
                     reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
               } else if(indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
                 hit = true;
@@ -251,11 +259,11 @@ public class PathTracer implements RayTracer {
               hit = pathTrace(scene, reflected, state, 0, false) || hit;
               if (hit) {
                 ray.color.x =
-                  (addEmitted * ray.emittance.x) + ray.color.x * ((reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
+                  (addEmitted * ray.apparentBrightness.x) + (addEmitted * ray.emittance.x) + ray.color.x * ((reflected.color.x + reflected.emittance.x) + (indirectEmitterColor.x));
                 ray.color.y =
-                  (addEmitted * ray.emittance.y) + ray.color.y * ((reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
+                  (addEmitted * ray.apparentBrightness.y) + (addEmitted * ray.emittance.y) + ray.color.y * ((reflected.color.y + reflected.emittance.y) + (indirectEmitterColor.y));
                 ray.color.z =
-                  (addEmitted * ray.emittance.z) + ray.color.z * ((reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
+                  (addEmitted * ray.apparentBrightness.z) + (addEmitted * ray.emittance.z) + ray.color.z * ((reflected.color.z + reflected.emittance.z) + (indirectEmitterColor.z));
               } else if(indirectEmitterColor.x > Ray.EPSILON || indirectEmitterColor.y > Ray.EPSILON || indirectEmitterColor.z > Ray.EPSILON) {
                 hit = true;
                 ray.color.x *= indirectEmitterColor.x;

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -131,6 +131,21 @@ public class Scene implements JsonSerializable, Refreshable {
   public static final double MAX_EMITTER_INTENSITY = 1000;
 
   /**
+   * Default apparent emitter brightness.
+   */
+  public static final double DEFAULT_APPARENT_EMITTER_BRIGHTNESS = 1;
+
+  /**
+   * Minimum apparent emitter brightness.
+   */
+  public static final double MIN_APPARENT_EMITTER_BRIGHTNESS = 0;
+
+  /**
+   * Maximum apparent emitter brightness.
+   */
+  public static final double MAX_APPARENT_EMITTER_BRIGHTNESS = 1000;
+
+  /**
    * Default exposure.
    */
   public static final double DEFAULT_EXPOSURE = 1.0;
@@ -195,6 +210,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean saveSnapshots = false;
   protected boolean emittersEnabled = DEFAULT_EMITTERS_ENABLED;
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
+  protected double apparentEmitterBrightness = DEFAULT_APPARENT_EMITTER_BRIGHTNESS;
   protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
 
   protected SunSamplingStrategy sunSamplingStrategy = SunSamplingStrategy.FAST;
@@ -459,6 +475,7 @@ public class Scene implements JsonSerializable, Refreshable {
     sunSamplingStrategy = other.sunSamplingStrategy;
     emittersEnabled = other.emittersEnabled;
     emitterIntensity = other.emitterIntensity;
+    apparentEmitterBrightness = other.apparentEmitterBrightness;
     emitterSamplingStrategy = other.emitterSamplingStrategy;
     preventNormalEmitterWithSampling = other.preventNormalEmitterWithSampling;
     transparentSky = other.transparentSky;
@@ -1883,6 +1900,21 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * @return The current apparent emitter brightness
+   */
+  public double getApparentEmitterBrightness() {
+    return apparentEmitterBrightness;
+  }
+
+  /**
+   * Set the apparent emitter brightness.
+   */
+  public void setApparentEmitterBrightness(double value) {
+    apparentEmitterBrightness = value;
+    refresh();
+  }
+
+  /**
    * Set the transparent sky option.
    */
   public void setTransparentSky(boolean value) {
@@ -2729,6 +2761,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("saveSnapshots", saveSnapshots);
     json.add("emittersEnabled", emittersEnabled);
     json.add("emitterIntensity", emitterIntensity);
+    json.add("apparentEmitterBrightness", apparentEmitterBrightness);
     json.add("sunSamplingStrategy", sunSamplingStrategy.getId());
     json.add("stillWater", stillWater);
     json.add("waterOpacity", waterOpacity);
@@ -3012,6 +3045,7 @@ public class Scene implements JsonSerializable, Refreshable {
     saveSnapshots = json.get("saveSnapshots").boolValue(saveSnapshots);
     emittersEnabled = json.get("emittersEnabled").boolValue(emittersEnabled);
     emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
+    apparentEmitterBrightness = json.get("apparentEmitterBrightness").doubleValue(apparentEmitterBrightness);
 
     if (json.get("sunSamplingStrategy").isUnknown()) {
       boolean sunSampling = json.get("sunEnabled").boolValue(false);
@@ -3317,6 +3351,16 @@ public class Scene implements JsonSerializable, Refreshable {
   public void setEmittance(String materialName, float value) {
     JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
     material.set("emittance", Json.of(value));
+    materials.put(materialName, material);
+    refresh(ResetReason.MATERIALS_CHANGED);
+  }
+
+  /**
+   * Modifies the apparent brightness property for the given material.
+   */
+  public void setApparentBrightness(String materialName, float value) {
+    JsonObject material = materials.getOrDefault(materialName, new JsonObject()).object();
+    material.set("apparentBrightness", Json.of(value));
     materials.put(materialName, material);
     refresh(ResetReason.MATERIALS_CHANGED);
   }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -118,7 +118,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Default emitter intensity.
    */
-  public static final double DEFAULT_EMITTER_INTENSITY = 13;
+  public static final double DEFAULT_EMITTER_INTENSITY = 1;
 
   /**
    * Minimum emitter intensity.
@@ -129,6 +129,21 @@ public class Scene implements JsonSerializable, Refreshable {
    * Maximum emitter intensity.
    */
   public static final double MAX_EMITTER_INTENSITY = 1000;
+
+  /**
+   * Default emitter light intensity.
+   */
+  public static final double DEFAULT_EMITTER_LIGHT_INTENSITY = 13;
+
+  /**
+   * Minimum emitter light intensity.
+   */
+  public static final double MIN_EMITTER_LIGHT_INTENSITY = 0.01;
+
+  /**
+   * Maximum emitter light intensity.
+   */
+  public static final double MAX_EMITTER_LIGHT_INTENSITY = 50;
 
   /**
    * Default apparent emitter brightness.
@@ -143,7 +158,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Maximum apparent emitter brightness.
    */
-  public static final double MAX_APPARENT_EMITTER_BRIGHTNESS = 1000;
+  public static final double MAX_APPARENT_EMITTER_BRIGHTNESS = 50;
 
   /**
    * Default exposure.
@@ -210,6 +225,7 @@ public class Scene implements JsonSerializable, Refreshable {
   protected boolean saveSnapshots = false;
   protected boolean emittersEnabled = DEFAULT_EMITTERS_ENABLED;
   protected double emitterIntensity = DEFAULT_EMITTER_INTENSITY;
+  protected double emitterLightIntensity = DEFAULT_EMITTER_LIGHT_INTENSITY;
   protected double apparentEmitterBrightness = DEFAULT_APPARENT_EMITTER_BRIGHTNESS;
   protected EmitterSamplingStrategy emitterSamplingStrategy = EmitterSamplingStrategy.NONE;
 
@@ -475,6 +491,7 @@ public class Scene implements JsonSerializable, Refreshable {
     sunSamplingStrategy = other.sunSamplingStrategy;
     emittersEnabled = other.emittersEnabled;
     emitterIntensity = other.emitterIntensity;
+    emitterLightIntensity = other.emitterLightIntensity;
     apparentEmitterBrightness = other.apparentEmitterBrightness;
     emitterSamplingStrategy = other.emitterSamplingStrategy;
     preventNormalEmitterWithSampling = other.preventNormalEmitterWithSampling;
@@ -1900,6 +1917,21 @@ public class Scene implements JsonSerializable, Refreshable {
   }
 
   /**
+   * @return The current emitter light intensity
+   */
+  public double getEmitterLightIntensity() {
+    return emitterLightIntensity;
+  }
+
+  /**
+   * Set the emitter light intensity.
+   */
+  public void setEmitterLightIntensity(double value) {
+    emitterLightIntensity = value;
+    refresh();
+  }
+
+  /**
    * @return The current apparent emitter brightness
    */
   public double getApparentEmitterBrightness() {
@@ -2761,6 +2793,7 @@ public class Scene implements JsonSerializable, Refreshable {
     json.add("saveSnapshots", saveSnapshots);
     json.add("emittersEnabled", emittersEnabled);
     json.add("emitterIntensity", emitterIntensity);
+    json.add("emitterLightIntensity", emitterLightIntensity);
     json.add("apparentEmitterBrightness", apparentEmitterBrightness);
     json.add("sunSamplingStrategy", sunSamplingStrategy.getId());
     json.add("stillWater", stillWater);
@@ -3044,7 +3077,14 @@ public class Scene implements JsonSerializable, Refreshable {
     dumpFrequency = json.get("dumpFrequency").intValue(dumpFrequency);
     saveSnapshots = json.get("saveSnapshots").boolValue(saveSnapshots);
     emittersEnabled = json.get("emittersEnabled").boolValue(emittersEnabled);
-    emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
+    if (json.get("emitterLightIntensity").isUnknown()) {
+      // load equivalent values in scenes saved in older versions.
+      emitterIntensity = 1;
+      emitterLightIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
+    } else {
+      emitterIntensity = json.get("emitterIntensity").doubleValue(emitterIntensity);
+      emitterLightIntensity = json.get("emitterLightIntensity").doubleValue(emitterLightIntensity);
+    }
     apparentEmitterBrightness = json.get("apparentEmitterBrightness").doubleValue(apparentEmitterBrightness);
 
     if (json.get("sunSamplingStrategy").isUnknown()) {

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -52,6 +52,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private DoubleAdjuster skyIntensity;
   @FXML private DoubleAdjuster apparentSkyBrightness;
   @FXML private DoubleAdjuster emitterIntensity;
+  @FXML private DoubleAdjuster apparentEmitterBrightness;
   @FXML private DoubleAdjuster sunIntensity;
   @FXML private CheckBox drawSun;
   @FXML private ComboBox<SunSamplingStrategy> sunSamplingStrategy;
@@ -109,6 +110,13 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     emitterIntensity.makeLogarithmic();
     emitterIntensity.clampMin();
     emitterIntensity.onValueChange(value -> scene.setEmitterIntensity(value));
+
+    apparentEmitterBrightness.setName("Apparent emitter brightness");
+    apparentEmitterBrightness.setTooltip("Modifies the apparent brightness of emitters.");
+    apparentEmitterBrightness.setRange(Scene.MIN_APPARENT_EMITTER_BRIGHTNESS, Scene.MAX_APPARENT_EMITTER_BRIGHTNESS);
+    apparentEmitterBrightness.makeLogarithmic();
+    apparentEmitterBrightness.clampMin();
+    apparentEmitterBrightness.onValueChange(value -> scene.setApparentEmitterBrightness(value));
 
     emitterSamplingStrategy.getItems().addAll(EmitterSamplingStrategy.values());
     emitterSamplingStrategy.getSelectionModel().selectedItemProperty()
@@ -194,6 +202,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     skyIntensity.set(scene.sky().getSkyLight());
     apparentSkyBrightness.set(scene.sky().getApparentSkyLight());
     emitterIntensity.set(scene.getEmitterIntensity());
+    apparentEmitterBrightness.set(scene.getApparentEmitterBrightness());
     sunIntensity.set(scene.sun().getIntensity());
     sunLuminosity.set(scene.sun().getLuminosity());
     apparentSunBrightness.set(scene.sun().getApparentBrightness());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/LightingTab.java
@@ -52,6 +52,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private DoubleAdjuster skyIntensity;
   @FXML private DoubleAdjuster apparentSkyBrightness;
   @FXML private DoubleAdjuster emitterIntensity;
+  @FXML private DoubleAdjuster emitterLightIntensity;
   @FXML private DoubleAdjuster apparentEmitterBrightness;
   @FXML private DoubleAdjuster sunIntensity;
   @FXML private CheckBox drawSun;
@@ -105,11 +106,18 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
       (observable, oldValue, newValue) -> scene.setEmittersEnabled(newValue));
 
     emitterIntensity.setName("Emitter intensity");
-    emitterIntensity.setTooltip("Modifies the intensity of emitter light.");
+    emitterIntensity.setTooltip("Changes the brightness of emitters.");
     emitterIntensity.setRange(Scene.MIN_EMITTER_INTENSITY, Scene.MAX_EMITTER_INTENSITY);
     emitterIntensity.makeLogarithmic();
     emitterIntensity.clampMin();
     emitterIntensity.onValueChange(value -> scene.setEmitterIntensity(value));
+
+    emitterLightIntensity.setName("Emitter light intensity");
+    emitterLightIntensity.setTooltip("Modifies the intensity of emitter light.");
+    emitterLightIntensity.setRange(Scene.MIN_EMITTER_LIGHT_INTENSITY, Scene.MAX_EMITTER_LIGHT_INTENSITY);
+    emitterLightIntensity.makeLogarithmic();
+    emitterLightIntensity.clampMin();
+    emitterLightIntensity.onValueChange(value -> scene.setEmitterLightIntensity(value));
 
     apparentEmitterBrightness.setName("Apparent emitter brightness");
     apparentEmitterBrightness.setTooltip("Modifies the apparent brightness of emitters.");
@@ -202,6 +210,7 @@ public class LightingTab extends ScrollPane implements RenderControlsTab, Initia
     skyIntensity.set(scene.sky().getSkyLight());
     apparentSkyBrightness.set(scene.sky().getApparentSkyLight());
     emitterIntensity.set(scene.getEmitterIntensity());
+    emitterLightIntensity.set(scene.getEmitterLightIntensity());
     apparentEmitterBrightness.set(scene.getApparentEmitterBrightness());
     sunIntensity.set(scene.sun().getIntensity());
     sunLuminosity.set(scene.sun().getLuminosity());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
@@ -95,7 +95,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     settings.setSpacing(10);
     settings.getChildren().addAll(
         new Label("Material Properties"),
-        emittance, apparentBrightness, perceptualSmoothness, ior, metalness,
+        emittance, apparentBrightness, specular, perceptualSmoothness, ior, metalness,
         new Label("(set to zero to disable)"));
     setPadding(new Insets(10));
     setSpacing(15);

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/MaterialsTab.java
@@ -50,6 +50,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
   private Scene scene;
 
   private final DoubleAdjuster emittance = new DoubleAdjuster();
+  private final DoubleAdjuster apparentBrightness = new DoubleAdjuster();
   private final DoubleAdjuster specular = new DoubleAdjuster();
   private final DoubleAdjuster ior = new DoubleAdjuster();
   private final DoubleAdjuster perceptualSmoothness = new DoubleAdjuster();
@@ -60,9 +61,15 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     emittance.setName("Emittance");
     emittance.setRange(0, 100);
     emittance.setTooltip("Intensity of the light emitted from the selected material.");
+    emittance.clampMin();
+    apparentBrightness.setName("Apparent Brightness");
+    apparentBrightness.setRange(0, 100);
+    apparentBrightness.setTooltip("Apparent brightness of the texture of the selected material.");
+    apparentBrightness.clampMin();
     specular.setName("Specular");
     specular.setRange(0, 1);
     specular.setTooltip("Reflectivity of the selected material.");
+    specular.clampBoth();
     ior.setName("IoR");
     ior.setRange(0, 5);
     ior.setTooltip("Index of Refraction of the selected material.");
@@ -72,6 +79,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     metalness.setName("Metalness");
     metalness.setRange(0, 1);
     metalness.setTooltip("Metalness (texture-tinted reflectivity) of the selected material.");
+    metalness.clampBoth();
     ObservableList<String> blockIds = FXCollections.observableArrayList();
     blockIds.addAll(MaterialStore.collections.keySet());
     blockIds.addAll(ExtraMaterials.idMap.keySet());
@@ -87,7 +95,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     settings.setSpacing(10);
     settings.getChildren().addAll(
         new Label("Material Properties"),
-        emittance, specular, perceptualSmoothness, ior, metalness,
+        emittance, apparentBrightness, perceptualSmoothness, ior, metalness,
         new Label("(set to zero to disable)"));
     setPadding(new Insets(10));
     setSpacing(15);
@@ -113,6 +121,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     boolean materialExists = false;
     if (MaterialStore.collections.containsKey(materialName)) {
       double emAcc = 0;
+      double apparentBrightnessAcc = 0;
       double specAcc = 0;
       double iorAcc = 0;
       double perceptualSmoothnessAcc = 0;
@@ -120,12 +129,14 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       Collection<Block> blocks = MaterialStore.collections.get(materialName);
       for (Block block : blocks) {
         emAcc += block.emittance;
+        apparentBrightnessAcc += block.apparentBrightness;
         specAcc += block.specular;
         iorAcc += block.ior;
         perceptualSmoothnessAcc += block.getPerceptualSmoothness();
         metalnessAcc += block.metalness;
       }
       emittance.set(emAcc / blocks.size());
+      apparentBrightness.set(apparentBrightnessAcc / blocks.size());
       specular.set(specAcc / blocks.size());
       ior.set(iorAcc / blocks.size());
       perceptualSmoothness.set(perceptualSmoothnessAcc / blocks.size());
@@ -135,6 +146,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       Material material = ExtraMaterials.idMap.get(materialName);
       if (material != null) {
         emittance.set(material.emittance);
+        apparentBrightness.set(material.apparentBrightness);
         specular.set(material.specular);
         ior.set(material.ior);
         perceptualSmoothness.set(material.getPerceptualSmoothness());
@@ -145,6 +157,7 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
       Block block = new MinecraftBlock(materialName.substring(10), Texture.air);
       scene.getPalette().applyMaterial(block);
       emittance.set(block.emittance);
+      apparentBrightness.set(block.apparentBrightness);
       specular.set(block.specular);
       ior.set(block.ior);
       perceptualSmoothness.set(block.getPerceptualSmoothness());
@@ -153,12 +166,14 @@ public class MaterialsTab extends HBox implements RenderControlsTab, Initializab
     }
     if (materialExists) {
       emittance.onValueChange(value -> scene.setEmittance(materialName, value.floatValue()));
+      apparentBrightness.onValueChange(value -> scene.setApparentBrightness(materialName, value.floatValue()));
       specular.onValueChange(value -> scene.setSpecular(materialName, value.floatValue()));
       ior.onValueChange(value -> scene.setIor(materialName, value.floatValue()));
       perceptualSmoothness.onValueChange(value -> scene.setPerceptualSmoothness(materialName, value.floatValue()));
       metalness.onValueChange(value -> scene.setMetalness(materialName, value.floatValue()));
     } else {
       emittance.onValueChange(value -> {});
+      apparentBrightness.onValueChange(value -> {});
       specular.onValueChange(value -> {});
       ior.onValueChange(value -> {});
       perceptualSmoothness.onValueChange(value -> {});

--- a/chunky/src/java/se/llbit/chunky/world/Material.java
+++ b/chunky/src/java/se/llbit/chunky/world/Material.java
@@ -61,6 +61,11 @@ public abstract class Material {
   public float emittance = 0;
 
   /**
+   * The apparent brightness of the material.
+   */
+  public float apparentBrightness = 1;
+
+  /**
    * The (linear) roughness controlling how rough a shiny block appears. A value of 0 makes the
    * surface perfectly specular, a value of 1 makes it diffuse.
    */
@@ -103,6 +108,7 @@ public abstract class Material {
     solid = true;
     specular = 0;
     emittance = 0;
+    apparentBrightness = 1;
     roughness = 0;
     subSurfaceScattering = false;
   }
@@ -123,6 +129,7 @@ public abstract class Material {
     ior = json.get("ior").floatValue(ior);
     specular = json.get("specular").floatValue(specular);
     emittance = json.get("emittance").floatValue(emittance);
+    apparentBrightness = json.get("apparentBrightness").floatValue(apparentBrightness);
     roughness = json.get("roughness").floatValue(roughness);
     metalness = json.get("metalness").floatValue(metalness);
   }

--- a/chunky/src/java/se/llbit/math/Ray.java
+++ b/chunky/src/java/se/llbit/math/Ray.java
@@ -75,6 +75,11 @@ public class Ray {
   public Vector3 emittance = new Vector3();
 
   /**
+   * Apparent brightness of previously intersected surface.
+   */
+  public Vector3 apparentBrightness = new Vector3();
+
+  /**
    * Previous material.
    */
   private Material prevMaterial = Air.INSTANCE;
@@ -151,6 +156,7 @@ public class Ray {
     depth = 0;
     color.set(0, 0, 0, 0);
     emittance.set(0, 0, 0);
+    apparentBrightness.set(0, 0, 0);
     specular = true;
   }
 
@@ -168,6 +174,7 @@ public class Ray {
     geomN.set(other.geomN);
     color.set(0, 0, 0, 0);
     emittance.set(0, 0, 0);
+    apparentBrightness.set(0, 0, 0);
     specular = other.specular;
   }
 

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -21,6 +21,7 @@
     <Separator />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
+    <DoubleAdjuster fx:id="apparentEmitterBrightness" maxWidth="1.7976931348623157E308" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Emitter Sampling Strategy:" />
       <ChoiceBox fx:id="emitterSamplingStrategy" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/LightingTab.fxml
@@ -21,6 +21,7 @@
     <Separator />
     <CheckBox fx:id="enableEmitters" mnemonicParsing="false" text="Enable emitters" />
     <DoubleAdjuster fx:id="emitterIntensity" maxWidth="1.7976931348623157E308" />
+    <DoubleAdjuster fx:id="emitterLightIntensity" maxWidth="1.7976931348623157E308" />
     <DoubleAdjuster fx:id="apparentEmitterBrightness" maxWidth="1.7976931348623157E308" />
     <HBox alignment="CENTER_LEFT" spacing="10.0">
       <Label text="Emitter Sampling Strategy:" />


### PR DESCRIPTION
- Changed `Emitter intensity` to scale both emitter light intensity and apparent emitter brightness. Changed its default value to *1*.
- Added `Emitter light intensity`, which scales only the emitter light intensity. Its default value is *13*, to reflect the default value of `Emitter intensity` from previous versions.
- Added `Apparent emitter brightness`, which scales only the apparent brighness of emitters. Its default value is *1*.
- Added an `Apparent brightness` material property, which changes the apparent brightness of the material when it behaves as an emitter. Its default value is *1*
- When loading scenes saved in an older Chunky version, Chunky will load the value of `Emitter intensity` as the value of `Emitter light intensity`, and set `Emitter intensity` to *1*.

**New:**
![image](https://user-images.githubusercontent.com/92183530/221417100-5d4a2228-a226-4c87-b6b1-a78e68736b07.png)
![image](https://user-images.githubusercontent.com/92183530/221417125-497fd9d5-db2b-4a10-a0d0-a76f0e03a2e1.png)
