### PR TITLE
Implement JsonSerializable and add GUI

### DIFF
--- a/chunky/src/java/se/llbit/chunky/renderer/scene/CuboidFogVolume.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/CuboidFogVolume.java
@@ -1,6 +1,7 @@
 package se.llbit.chunky.renderer.scene;
 
-import se.llbit.chunky.world.material.ParticleFogMaterial;
+import org.apache.commons.math3.util.FastMath;
+import se.llbit.json.JsonObject;
 import se.llbit.math.AABB;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
@@ -8,13 +9,18 @@ import se.llbit.math.Vector3;
 import java.util.Random;
 
 public class CuboidFogVolume extends FogVolume {
-
+  private static final double DEFAULT_XMIN = -10;
+  private static final double DEFAULT_XMAX = 10;
+  private static final double DEFAULT_YMIN = 100;
+  private static final double DEFAULT_YMAX = 120;
+  private static final double DEFAULT_ZMIN = -10;
+  private static final double DEFAULT_ZMAX = 10;
   private AABB aabb;
 
   @Override
   public boolean intersect(Ray ray, Scene scene, Random random) {
     double distance;
-    double fogPenetrated = -Math.log(1 - random.nextDouble());
+    double fogPenetrated = -FastMath.log(1 - random.nextDouble());
     double fogDistance = fogPenetrated / density;
     AABB aabbTranslated = aabb.getTranslated(-scene.origin.x, -scene.origin.y, -scene.origin.z);
     if (!aabbTranslated.inside(ray.o)) {
@@ -29,7 +35,7 @@ public class CuboidFogVolume extends FogVolume {
       distance = fogDistance;
     }
 
-    if (distance > ray.t) {
+    if (distance >= ray.t) {
       return false;
     }
 
@@ -46,22 +52,58 @@ public class CuboidFogVolume extends FogVolume {
   }
 
   public void setBounds(double xmin, double xmax, double ymin, double ymax, double zmin, double zmax) {
-    this.aabb = new AABB(xmin, xmax, ymin, ymax, zmin, zmax);
+    setBounds(new AABB(xmin, xmax, ymin, ymax, zmin, zmax));
   }
 
-  public void setBounds(AABB aabb) {
+  private void setBounds(AABB aabb) {
     this.aabb = aabb;
+  }
+
+  public AABB getBounds() {
+    return new AABB(this.aabb.xmin, this.aabb.xmax, this.aabb.ymin, this.aabb.ymax, this.aabb.zmin, this.aabb.zmax);
   }
 
   public CuboidFogVolume(Vector3 color, double density, double xmin, double xmax, double ymin, double ymax, double zmin, double zmax) {
-    this.aabb = new AABB(xmin, xmax, ymin, ymax, zmin, zmax);
-    this.color = color;
-    this.density = density;
+    this(color, density, new AABB(xmin, xmax, ymin, ymax, zmin, zmax));
   }
 
   public CuboidFogVolume(Vector3 color, double density, AABB aabb) {
+    this.type = FogVolumeType.CUBOID;
     this.aabb = aabb;
-    this.color = color;
+    this.color = new Vector3(color);
     this.density = density;
+  }
+
+  public CuboidFogVolume(Vector3 color, double density) {
+    this(color, density, new AABB(DEFAULT_XMIN, DEFAULT_XMAX, DEFAULT_YMIN, DEFAULT_YMAX, DEFAULT_ZMIN, DEFAULT_ZMAX));
+  }
+
+  @Override
+  public JsonObject volumeSpecificPropertiesToJson() {
+    JsonObject properties = new JsonObject();
+    JsonObject pos1 = new JsonObject();
+    pos1.add("x", aabb.xmin);
+    pos1.add("y", aabb.ymin);
+    pos1.add("z", aabb.zmin);
+    properties.add("pos1", pos1);
+    JsonObject pos2 = new JsonObject();
+    pos2.add("x", aabb.xmax);
+    pos2.add("y", aabb.ymax);
+    pos2.add("z", aabb.zmax);
+    properties.add("pos2", pos2);
+    return properties;
+  }
+
+  @Override
+  public void importVolumeSpecificProperties(JsonObject json) {
+    JsonObject pos1 = json.get("pos1").object();
+    double x1 = pos1.get("x").doubleValue(aabb.xmin);
+    double y1 = pos1.get("y").doubleValue(aabb.ymin);
+    double z1 = pos1.get("z").doubleValue(aabb.zmin);
+    JsonObject pos2 = json.get("pos2").object();
+    double x2 = pos2.get("x").doubleValue(aabb.xmax);
+    double y2 = pos2.get("y").doubleValue(aabb.ymax);
+    double z2 = pos2.get("z").doubleValue(aabb.zmax);
+    aabb = new AABB(x1, x2, y1, y2, z1, z2);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogVolume.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogVolume.java
@@ -3,12 +3,15 @@ package se.llbit.chunky.renderer.scene;
 import org.apache.commons.math3.util.FastMath;
 import se.llbit.chunky.world.Material;
 import se.llbit.chunky.world.material.ParticleFogMaterial;
+import se.llbit.json.JsonObject;
 import se.llbit.math.Ray;
 import se.llbit.math.Vector3;
+import se.llbit.util.JsonSerializable;
 
 import java.util.Random;
 
-public abstract class FogVolume {
+public abstract class FogVolume implements JsonSerializable {
+  protected FogVolumeType type;
   protected Vector3 color;
   protected double density;
   protected Material material = new ParticleFogMaterial();
@@ -43,6 +46,46 @@ public abstract class FogVolume {
     return material;
   }
 
+  public double getEmittance() {
+    return this.material.emittance;
+  }
+
+  public void setEmittance(float value) {
+    this.material.emittance = value;
+  }
+
+  public double getSpecular() {
+    return this.material.specular;
+  }
+
+  public void setSpecular(float value) {
+    this.material.specular = value;
+  }
+
+  public double getSmoothness() {
+    return this.material.getPerceptualSmoothness();
+  }
+
+  public void setSmoothness(double value) {
+    this.material.setPerceptualSmoothness(value);
+  }
+
+  public double getIor() {
+    return this.material.ior;
+  }
+
+  public void setIor(float value) {
+    this.material.ior = value;
+  }
+
+  public double getMetalness() {
+    return this.material.metalness;
+  }
+
+  public void setMetalness(float value) {
+    this.material.metalness = value;
+  }
+
   public void setDensity(double value) {
     this.density = value;
   }
@@ -56,6 +99,57 @@ public abstract class FogVolume {
   }
 
   public Vector3 getColor() {
-    return color;
+    return new Vector3(color);
+  }
+
+  public FogVolumeType getType() {
+    return type;
+  }
+
+  protected abstract JsonObject volumeSpecificPropertiesToJson();
+
+  @Override
+  public JsonObject toJson() {
+    JsonObject properties = volumeSpecificPropertiesToJson();
+    properties.add("type", type.name());
+    JsonObject colorObj = new JsonObject();
+    colorObj.add("red", color.x);
+    colorObj.add("green", color.y);
+    colorObj.add("blue", color.z);
+    properties.add("color", colorObj);
+    properties.add("density", density);
+    properties.add("materialProperties", materialPropertiesToJson());
+    return properties;
+  }
+
+  protected JsonObject materialPropertiesToJson() {
+    JsonObject materialProperties = new JsonObject();
+    materialProperties.add("emittance", material.emittance);
+    materialProperties.add("specular", material.specular);
+    materialProperties.add("roughness", material.roughness);
+    materialProperties.add("ior", material.ior);
+    materialProperties.add("metalness", material.metalness);
+    return materialProperties;
+  }
+
+  protected abstract void importVolumeSpecificProperties(JsonObject jsonObject);
+
+  public void importFromJson(JsonObject json) {
+    JsonObject colorObj = json.get("color").object();
+    color.x = colorObj.get("red").doubleValue(color.x);
+    color.y = colorObj.get("green").doubleValue(color.y);
+    color.z = colorObj.get("blue").doubleValue(color.z);
+    density = json.get("density").doubleValue(Scene.DEFAULT_FOG_DENSITY);
+    JsonObject materialProperties = json.get("materialProperties").object();
+    importMaterialProperties(materialProperties);
+    importVolumeSpecificProperties(json);
+  }
+
+  protected void importMaterialProperties(JsonObject json) {
+    material.emittance = json.get("emittance").floatValue(material.emittance);
+    material.specular = json.get("specular").floatValue(material.specular);
+    material.roughness = json.get("roughness").floatValue(material.roughness);
+    material.ior = json.get("ior").floatValue(material.ior);
+    material.metalness = json.get("metalness").floatValue(material.metalness);
   }
 }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/FogVolumeType.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/FogVolumeType.java
@@ -1,0 +1,6 @@
+package se.llbit.chunky.renderer.scene;
+
+public enum FogVolumeType {
+  EXPONENTIAL, LAYER, SPHERE, CUBOID
+
+}

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PathTracer.java
@@ -84,7 +84,7 @@ public class PathTracer implements RayTracer {
         } else {
           // Indirect sky hit - diffuse color.
           scene.sky.getSkyColorDiffuseSun(ray, scene.getSunSamplingStrategy().isDiffuseSun());
-          // Skip sky fog - likely not noticeable in diffuse reflection.
+          addSkyFog(scene, ray, state, ox, od);
           hit = true;
         }
         break;
@@ -170,7 +170,7 @@ public class PathTracer implements RayTracer {
         airDistance = ray.distance;
       }
     }
-/*
+
     // This is a simplistic fog model which gives greater artistic freedom but
     // less realism. The user can select fog color and density; in a more
     // realistic model color would depend on viewing angle and sun color/position.
@@ -197,7 +197,7 @@ public class PathTracer implements RayTracer {
       getDirectLightAttenuation(scene, atmos, state);
       scene.fog.addGroundFog(ray, ox, airDistance, state.attenuation, offset);
     }
-*/
+
     return hit;
   }
 

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/PreviewRayTracer.java
@@ -43,7 +43,7 @@ public class PreviewRayTracer implements RayTracer {
       ray.setCurrentMaterial(Air.INSTANCE);
     }
     while (true) {
-      if (!nextIntersection(scene, ray)) {
+      if (!nextIntersection(scene, ray, scene.getPreviewParticleFog(), state.random)) {
         if (mapIntersection(scene, ray)) {
           break;
         }

--- a/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
+++ b/chunky/src/java/se/llbit/chunky/renderer/scene/Scene.java
@@ -149,7 +149,7 @@ public class Scene implements JsonSerializable, Refreshable {
   /**
    * Default fog density.
    */
-  public static final double DEFAULT_FOG_DENSITY = 0.0;
+  public static final double DEFAULT_FOG_DENSITY = 0.05;
 
   /**
    * Default post processing filter.
@@ -343,6 +343,8 @@ public class Scene implements JsonSerializable, Refreshable {
 
   protected volatile boolean isLoading = false;
 
+  private boolean previewParticleFog = PersistentSettings.getPreviewParticleFog();
+
   /**
    * Creates a scene with all default settings.
    *
@@ -454,6 +456,7 @@ public class Scene implements JsonSerializable, Refreshable {
     preventNormalEmitterWithSampling = other.preventNormalEmitterWithSampling;
     fancierTranslucency = other.fancierTranslucency;
     transmissivityCap = other.transmissivityCap;
+    previewParticleFog = other.previewParticleFog;
     transparentSky = other.transparentSky;
     yClipMin = other.yClipMin;
     yClipMax = other.yClipMax;
@@ -3429,6 +3432,16 @@ public class Scene implements JsonSerializable, Refreshable {
 
   public void setTransmissivityCap(double value) {
     transmissivityCap = value;
+    refresh();
+  }
+
+  public boolean getPreviewParticleFog() {
+    return this.previewParticleFog;
+  }
+
+  public void setPreviewParticleFog(boolean value) {
+    this.previewParticleFog = value;
+    PersistentSettings.setPreviewParticleFog(value);
     refresh();
   }
 }

--- a/chunky/src/java/se/llbit/chunky/ui/controller/RenderControlsFxController.java
+++ b/chunky/src/java/se/llbit/chunky/ui/controller/RenderControlsFxController.java
@@ -98,6 +98,7 @@ public class RenderControlsFxController {
       tabs.add(new GeneralTab());
       tabs.add(new LightingTab());
       tabs.add(new SkyTab());
+      tabs.add(new FogTab());
       tabs.add(new WaterTab());
       tabs.add(new CameraTab());
       tabs.add(new EntitiesTab());

--- a/chunky/src/java/se/llbit/chunky/ui/dialogs/FogVolumeTypeSelectorDialog.java
+++ b/chunky/src/java/se/llbit/chunky/ui/dialogs/FogVolumeTypeSelectorDialog.java
@@ -1,0 +1,32 @@
+package se.llbit.chunky.ui.dialogs;
+
+import javafx.geometry.Insets;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.ChoiceBox;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.DialogPane;
+import javafx.scene.layout.VBox;
+import se.llbit.chunky.renderer.scene.FogVolumeType;
+
+public class FogVolumeTypeSelectorDialog extends Dialog<ButtonType> {
+  protected ChoiceBox<FogVolumeType> choiceBox = new ChoiceBox<>();
+
+  public FogVolumeTypeSelectorDialog() {
+    this.setTitle("Select fog volume type");
+
+    DialogPane dialogPane = this.getDialogPane();
+    VBox vBox = new VBox();
+
+    choiceBox.getItems().addAll(FogVolumeType.values());
+
+    vBox.getChildren().add(choiceBox);
+    vBox.setPadding(new Insets(10));
+
+    dialogPane.setContent(vBox);
+    dialogPane.getButtonTypes().addAll(ButtonType.OK, ButtonType.CANCEL);
+  }
+
+  public FogVolumeType getType() {
+    return choiceBox.getSelectionModel().getSelectedItem();
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/ui/render/settings/UniformFogSettings.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/settings/UniformFogSettings.java
@@ -51,7 +51,7 @@ public class UniformFogSettings extends VBox implements Initializable {
 
   @Override public void initialize(URL location, ResourceBundle resources) {
     fogDensity.setTooltip("Fog thickness. Set to 0 to disable volumetric fog effect.");
-    fogDensity.setRange(0, 1);
+    fogDensity.setRange(0.000001, 1);
     fogDensity.setMaximumFractionDigits(6);
     fogDensity.makeLogarithmic();
     fogDensity.clampMin();

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/AdvancedTab.java
@@ -69,6 +69,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
   @FXML private CheckBox shutdown;
   @FXML private CheckBox fastFog;
   @FXML private CheckBox fancierTranslucency;
+  @FXML private CheckBox previewParticleFog;
   @FXML private DoubleAdjuster transmissivityCap;
   @FXML private IntegerAdjuster cacheResolution;
   @FXML private DoubleAdjuster animationTime;
@@ -163,6 +164,12 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
         transmissivityCap.setVisible(newValue);
         transmissivityCap.setManaged(newValue);
       });
+
+    previewParticleFog.setTooltip(new Tooltip("Render particle fog in the render preview."));
+    previewParticleFog.selectedProperty().addListener((observer, oldValue, newValue) ->
+      scene.setPreviewParticleFog(newValue)
+    );
+
     boolean tcapVisible = scene != null && scene.getFancierTranslucency();
     transmissivityCap.setVisible(tcapVisible);
     transmissivityCap.setManaged(tcapVisible);
@@ -334,6 +341,7 @@ public class AdvancedTab extends ScrollPane implements RenderControlsTab, Initia
     outputMode.getSelectionModel().select(scene.getOutputMode());
     fastFog.setSelected(scene.fog.fastFog());
     fancierTranslucency.setSelected(scene.getFancierTranslucency());
+    previewParticleFog.setSelected(scene.getPreviewParticleFog());
     transmissivityCap.set(scene.getTransmissivityCap());
     renderThreads.set(PersistentSettings.getNumThreads());
     cpuLoad.set(PersistentSettings.getCPULoad());

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/FogTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/FogTab.java
@@ -1,0 +1,505 @@
+/* Copyright (c) 2016 - 2021 Jesper Öqvist <jesper@llbit.se>
+ * Copyright (c) 2016 - 2021 Chunky contributors
+ *
+ * This file is part of Chunky.
+ *
+ * Chunky is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Chunky is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with Chunky.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package se.llbit.chunky.ui.render.tabs;
+
+import javafx.beans.property.ReadOnlyStringWrapper;
+import javafx.fxml.FXML;
+import javafx.fxml.FXMLLoader;
+import javafx.fxml.Initializable;
+import javafx.scene.Node;
+import javafx.scene.control.*;
+import javafx.scene.layout.*;
+import se.llbit.chunky.renderer.scene.*;
+import se.llbit.chunky.ui.DoubleAdjuster;
+import se.llbit.chunky.ui.DoubleTextField;
+import se.llbit.chunky.ui.controller.RenderControlsFxController;
+import se.llbit.chunky.ui.dialogs.FogVolumeTypeSelectorDialog;
+import se.llbit.chunky.ui.elements.TextFieldLabelWrapper;
+import se.llbit.chunky.ui.render.RenderControlsTab;
+import se.llbit.chunky.ui.render.settings.LayeredFogSettings;
+import se.llbit.chunky.ui.render.settings.UniformFogSettings;
+import se.llbit.fx.LuxColorPicker;
+import se.llbit.math.AABB;
+import se.llbit.math.ColorUtil;
+import se.llbit.math.Vector3;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ResourceBundle;
+
+public class FogTab extends ScrollPane implements RenderControlsTab, Initializable {
+  private Scene scene;
+
+  private static class FogVolumeData {
+    final String type;
+
+    FogVolumeData(FogVolume fogVolume) {
+      this.type = fogVolume.getType().name();
+    }
+  }
+
+  @FXML private ComboBox<FogMode> fogMode;
+  @FXML private TitledPane fogDetailsPane;
+  @FXML private VBox fogDetailsBox;
+  @FXML private TableView<FogVolumeData> fogVolumeTable;
+  @FXML private TableColumn<FogVolumeData, String> typeCol;
+  @FXML private Button addVolume;
+  @FXML private Button removeVolume;
+  @FXML private VBox volumeSpecificControls;
+
+  private final UniformFogSettings uniformFogSettings = new UniformFogSettings();
+  private final LayeredFogSettings layeredFogSettings = new LayeredFogSettings();
+  private final FogVolumeTypeSelectorDialog fogVolumeTypeSelectorDialog = new FogVolumeTypeSelectorDialog();
+
+  public FogTab() throws IOException {
+    FXMLLoader loader = new FXMLLoader(getClass().getResource("FogTab.fxml"));
+    loader.setRoot(this);
+    loader.setController(this);
+    loader.load();
+  }
+
+  @Override public void setController(RenderControlsFxController controller) {
+    scene = controller.getRenderController().getSceneManager().getScene();
+    uniformFogSettings.setRenderController(controller.getRenderController());
+    layeredFogSettings.setRenderController(controller.getRenderController());
+  }
+
+  @Override public void initialize(URL location, ResourceBundle resources) {
+    fogMode.getItems().addAll(FogMode.values());
+    fogMode.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+      scene.setFogMode(newValue);
+      switch (newValue) {
+        case NONE: {
+          fogDetailsBox.getChildren().setAll(new Label("Selected mode has no settings."));
+          break;
+        }
+        case UNIFORM: {
+          fogDetailsBox.getChildren().setAll(uniformFogSettings);
+          break;
+        }
+        case LAYERED: {
+          fogDetailsBox.getChildren().setAll(layeredFogSettings);
+          break;
+        }
+      }
+      fogDetailsPane.setExpanded(true);
+    });
+
+    fogVolumeTable.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+      updateControls();
+    });
+    typeCol.setCellValueFactory(data -> new ReadOnlyStringWrapper(data.getValue().type));
+    typeCol.setSortable(false);
+
+    addVolume.setOnAction(e -> {
+      if (fogVolumeTypeSelectorDialog.showAndWait().orElse(ButtonType.CANCEL) == ButtonType.OK) {
+        FogVolumeType type = fogVolumeTypeSelectorDialog.getType();
+        scene.fog.addVolume(type);
+        rebuildList();
+        fogVolumeTable.getSelectionModel().selectLast();
+      }
+    });
+
+    removeVolume.setOnAction(e -> {
+      int index = fogVolumeTable.getSelectionModel().getSelectedIndex();
+      scene.fog.removeVolume(index);
+      rebuildList();
+    });
+  }
+
+  @Override public void update(Scene scene) {
+    fogMode.getSelectionModel().select(scene.fog.getFogMode());
+    uniformFogSettings.update(scene);
+    layeredFogSettings.update(scene);
+    rebuildList();
+  }
+
+  private void rebuildList() {
+    fogVolumeTable.getSelectionModel().clearSelection();
+    fogVolumeTable.getItems().clear();
+    for (FogVolume fogVolume : scene.fog.getFogVolumes()) {
+      FogVolumeData fogVolumeData = new FogVolumeData(fogVolume);
+      fogVolumeTable.getItems().add(fogVolumeData);
+    }
+  }
+
+  private void updateControls() {
+    volumeSpecificControls.getChildren().clear();
+    if (!fogVolumeTable.getSelectionModel().isEmpty()) {
+      int index = fogVolumeTable.getSelectionModel().getSelectedIndex();
+      FogVolume fogVolume = scene.fog.getFogVolumes().get(index);
+
+      DoubleAdjuster density = new DoubleAdjuster();
+      density.setName("Fog density");
+      density.setTooltip("Fog thickness");
+      density.setMaximumFractionDigits(6);
+      density.setRange(0.000001, 1);
+      density.clampMin();
+      density.set(fogVolume.getDensity());
+      density.onValueChange(value -> {
+        fogVolume.setDensity(value);
+        scene.refresh();
+      });
+
+      HBox fogColorPickerBox = new HBox();
+      fogColorPickerBox.setSpacing(10);
+      Label label = new Label("Fog color:");
+      LuxColorPicker luxColorPicker = new LuxColorPicker();
+      luxColorPicker.setColor(ColorUtil.toFx(fogVolume.getColor()));
+      luxColorPicker.colorProperty().addListener(
+        (observable, oldValue, newValue) -> {
+          fogVolume.setColor(ColorUtil.fromFx(newValue));
+          scene.refresh();
+        });
+      fogColorPickerBox.getChildren().addAll(label, luxColorPicker);
+
+      DoubleAdjuster emittance = new DoubleAdjuster();
+      emittance.setName("Emittance");
+      emittance.setRange(0, 100);
+      emittance.clampMin();
+      emittance.set(fogVolume.getEmittance());
+      emittance.onValueChange(value -> {
+        fogVolume.setEmittance(value.floatValue());
+        scene.refresh();
+      });
+
+      DoubleAdjuster specular = new DoubleAdjuster();
+      specular.setName("Specular");
+      specular.setRange(0, 1);
+      specular.clampBoth();
+      specular.set(fogVolume.getSpecular());
+      specular.onValueChange(value -> {
+        fogVolume.setSpecular(value.floatValue());
+        scene.refresh();
+      });
+
+      DoubleAdjuster smoothness = new DoubleAdjuster();
+      smoothness.setName("Smoothness");
+      smoothness.setRange(0, 1);
+      smoothness.clampBoth();
+      smoothness.set(fogVolume.getSmoothness());
+      smoothness.onValueChange(value -> {
+        fogVolume.setSmoothness(value.floatValue());
+        scene.refresh();
+      });
+
+      DoubleAdjuster ior = new DoubleAdjuster();
+      ior.setName("IoR");
+      ior.setRange(0, 5);
+      ior.set(fogVolume.getIor());
+      ior.onValueChange(value -> {
+        fogVolume.setIor(value.floatValue());
+        scene.refresh();
+      });
+
+      DoubleAdjuster metalness = new DoubleAdjuster();
+      metalness.setName("Metalness");
+      metalness.setRange(0, 1);
+      metalness.clampBoth();
+      metalness.set(fogVolume.getMetalness());
+      metalness.onValueChange(value -> {
+        fogVolume.setMetalness(value.floatValue());
+        scene.refresh();
+      });
+
+      Separator separator = new Separator();
+
+      volumeSpecificControls.getChildren().addAll(
+        density,
+        fogColorPickerBox,
+        emittance,
+        specular,
+        smoothness,
+        ior,
+        metalness,
+        separator
+      );
+
+      ColumnConstraints labelConstraints = new ColumnConstraints();
+      labelConstraints.setHgrow(Priority.NEVER);
+      labelConstraints.setPrefWidth(90);
+      ColumnConstraints posFieldConstraints = new ColumnConstraints();
+      posFieldConstraints.setMinWidth(20);
+      posFieldConstraints.setPrefWidth(90);
+
+      switch (fogVolume.getType()) {
+        case EXPONENTIAL: {
+          ExponentialFogVolume exponentialFogVolume = (ExponentialFogVolume) fogVolume;
+          DoubleAdjuster scaleHeight = new DoubleAdjuster();
+          scaleHeight.setName("Height scale");
+          scaleHeight.setTooltip("Scales the vertical distribution of the fog");
+          scaleHeight.setRange(1, 50);
+          scaleHeight.set(exponentialFogVolume.getScaleHeight());
+          scaleHeight.onValueChange(value -> {
+            exponentialFogVolume.setScaleHeight(value);
+            scene.refresh();
+          });
+
+          DoubleAdjuster yOffset = new DoubleAdjuster();
+          yOffset.setName("Y-offset");
+          yOffset.setTooltip("Y-offset (altitude) of the distribution");
+          yOffset.setRange(-100, 100);
+          yOffset.set(exponentialFogVolume.getYOffset());
+          yOffset.onValueChange(value -> {
+            exponentialFogVolume.setYOffset(value);
+            scene.refresh();
+          });
+
+          volumeSpecificControls.getChildren().addAll(scaleHeight, yOffset);
+          break;
+        }
+        case LAYER: {
+          LayerFogVolume layerFogVolume = (LayerFogVolume) fogVolume;
+          DoubleAdjuster layerBreadth = new DoubleAdjuster();
+          layerBreadth.setName("Layer thickness");
+          layerBreadth.setTooltip("Scales the vertical distribution of the fog");
+          layerBreadth.setRange(0.001, 100);
+          layerBreadth.set(layerFogVolume.getLayerBreadth());
+          layerBreadth.clampMin();
+          layerBreadth.onValueChange(value -> {
+            layerFogVolume.setLayerBreadth(value);
+            scene.refresh();
+          });
+
+          DoubleAdjuster yOffset = new DoubleAdjuster();
+          yOffset.setName("Layer altitude");
+          yOffset.setTooltip("Y-coordinate (altitude) of the fog layer");
+          yOffset.setRange(-64, 320);
+          yOffset.set(layerFogVolume.getYOffset());
+          yOffset.onValueChange(value -> {
+            layerFogVolume.setYOffset(value);
+            scene.refresh();
+          });
+
+          volumeSpecificControls.getChildren().addAll(layerBreadth, yOffset);
+          break;
+        }
+        case SPHERE: {
+          SphericalFogVolume sphericalFogVolume = (SphericalFogVolume) fogVolume;
+
+          DoubleTextField posX = new DoubleTextField();
+          DoubleTextField posY = new DoubleTextField();
+          DoubleTextField posZ = new DoubleTextField();
+
+          posX.setTooltip(new Tooltip("Sphere x-coordinate (east/west)"));
+          posY.setTooltip(new Tooltip("Sphere y-coordinate (up/down)"));
+          posZ.setTooltip(new Tooltip("Sphere z-coordinate (south/north)"));
+
+          Vector3 center = sphericalFogVolume.getCenter();
+          posX.valueProperty().setValue(center.x);
+          posY.valueProperty().setValue(center.y);
+          posZ.valueProperty().setValue(center.z);
+
+          posX.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              sphericalFogVolume.setCenterX(newValue.doubleValue());
+              scene.refresh();
+            });
+          posY.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              sphericalFogVolume.setCenterY(newValue.doubleValue());
+              scene.refresh();
+            });
+          posZ.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              sphericalFogVolume.setCenterZ(newValue.doubleValue());
+              scene.refresh();
+            });
+
+          TextFieldLabelWrapper xText = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper yText = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper zText = new TextFieldLabelWrapper();
+
+          xText.setTextField(posX);
+          yText.setTextField(posY);
+          zText.setTextField(posZ);
+
+          xText.setLabelText("x:");
+          yText.setLabelText("y:");
+          zText.setLabelText("z:");
+
+          GridPane gridPane = new GridPane();
+          gridPane.setHgap(6);
+          gridPane.getColumnConstraints().addAll(
+            labelConstraints,
+            posFieldConstraints,
+            posFieldConstraints,
+            posFieldConstraints
+          );
+          gridPane.addRow(0, new Label("Center:"), xText, yText, zText);
+
+          DoubleAdjuster radius = new DoubleAdjuster();
+          radius.setName("Radius");
+          radius.setTooltip("Radius of the sphere");
+          radius.setRange(0.001, 100);
+          radius.set(sphericalFogVolume.getRadius());
+          radius.clampMin();
+          radius.onValueChange(value -> {
+            sphericalFogVolume.setRadius(value);
+            scene.refresh();
+          });
+
+          volumeSpecificControls.getChildren().addAll(gridPane, radius);
+          break;
+        }
+        case CUBOID: {
+          CuboidFogVolume cuboidFogVolume = (CuboidFogVolume) fogVolume;
+
+          DoubleTextField x1 = new DoubleTextField();
+          DoubleTextField y1 = new DoubleTextField();
+          DoubleTextField z1 = new DoubleTextField();
+          DoubleTextField x2 = new DoubleTextField();
+          DoubleTextField y2 = new DoubleTextField();
+          DoubleTextField z2 = new DoubleTextField();
+
+          x1.setTooltip(new Tooltip("X-coordinate (east/west) of first corner"));
+          y1.setTooltip(new Tooltip("Y-coordinate (up/down) of first corner"));
+          z1.setTooltip(new Tooltip("Z-coordinate (south/north) of first corner"));
+          x2.setTooltip(new Tooltip("X-coordinate (east/west) of second corner"));
+          y2.setTooltip(new Tooltip("Y-coordinate (up/down) of second corner"));
+          z2.setTooltip(new Tooltip("Z-coordinate (south/north) of second corner"));
+
+          AABB bounds = cuboidFogVolume.getBounds();
+          x1.valueProperty().setValue(bounds.xmin);
+          y1.valueProperty().setValue(bounds.ymin);
+          z1.valueProperty().setValue(bounds.zmin);
+          x2.valueProperty().setValue(bounds.xmax);
+          y2.valueProperty().setValue(bounds.ymax);
+          z2.valueProperty().setValue(bounds.zmax);
+
+          x1.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              cuboidFogVolume.setBounds(
+                Math.min(newValue.doubleValue(), x2.valueProperty().doubleValue()),
+                Math.max(newValue.doubleValue(), x2.valueProperty().doubleValue()),
+                Math.min(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.max(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.min(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue()),
+                Math.max(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue())
+              );
+              scene.refresh();
+            });
+          y1.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              cuboidFogVolume.setBounds(
+                Math.min(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.max(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.min(newValue.doubleValue(), y2.valueProperty().doubleValue()),
+                Math.max(newValue.doubleValue(), y2.valueProperty().doubleValue()),
+                Math.min(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue()),
+                Math.max(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue())
+              );
+              scene.refresh();
+            });
+          z1.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              cuboidFogVolume.setBounds(
+                Math.min(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.max(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.min(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.max(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.min(newValue.doubleValue(), z2.valueProperty().doubleValue()),
+                Math.max(newValue.doubleValue(), z2.valueProperty().doubleValue())
+              );
+              scene.refresh();
+            });
+          x2.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              cuboidFogVolume.setBounds(
+                Math.min(x1.valueProperty().doubleValue(), newValue.doubleValue()),
+                Math.max(x1.valueProperty().doubleValue(), newValue.doubleValue()),
+                Math.min(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.max(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.min(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue()),
+                Math.max(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue())
+              );
+              scene.refresh();
+            });
+          y2.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              cuboidFogVolume.setBounds(
+                Math.min(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.max(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.min(y1.valueProperty().doubleValue(), newValue.doubleValue()),
+                Math.max(y1.valueProperty().doubleValue(), newValue.doubleValue()),
+                Math.min(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue()),
+                Math.max(z1.valueProperty().doubleValue(), z2.valueProperty().doubleValue())
+              );
+              scene.refresh();
+            });
+          z2.valueProperty().addListener(
+            (observable, oldValue, newValue) -> {
+              cuboidFogVolume.setBounds(
+                Math.min(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.max(x1.valueProperty().doubleValue(), x2.valueProperty().doubleValue()),
+                Math.min(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.max(y1.valueProperty().doubleValue(), y2.valueProperty().doubleValue()),
+                Math.min(z1.valueProperty().doubleValue(), newValue.doubleValue()),
+                Math.max(z1.valueProperty().doubleValue(), newValue.doubleValue())
+              );
+              scene.refresh();
+            });
+
+          TextFieldLabelWrapper x1Text = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper y1Text = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper z1Text = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper x2Text = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper y2Text = new TextFieldLabelWrapper();
+          TextFieldLabelWrapper z2Text = new TextFieldLabelWrapper();
+
+          x1Text.setTextField(x1);
+          y1Text.setTextField(y1);
+          z1Text.setTextField(z1);
+          x2Text.setTextField(x2);
+          y2Text.setTextField(y2);
+          z2Text.setTextField(z2);
+
+          x1Text.setLabelText("x:");
+          y1Text.setLabelText("y:");
+          z1Text.setLabelText("z:");
+          x2Text.setLabelText("x:");
+          y2Text.setLabelText("y:");
+          z2Text.setLabelText("z:");
+
+          GridPane gridPane = new GridPane();
+          gridPane.setHgap(6);
+          gridPane.setVgap(10);
+          gridPane.getColumnConstraints().addAll(
+            labelConstraints,
+            posFieldConstraints,
+            posFieldConstraints,
+            posFieldConstraints
+          );
+          gridPane.addRow(0, new Label("Corner 1:"), x1Text, y1Text, z1Text);
+          gridPane.addRow(1, new Label("Corner 2:"), x2Text, y2Text, z2Text);
+
+          volumeSpecificControls.getChildren().addAll(gridPane);
+          break;
+        }
+      }
+    }
+  }
+
+  @Override public String getTabTitle() {
+    return "Fog";
+  }
+
+  @Override public Node getTabContent() {
+    return this;
+  }
+}

--- a/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
+++ b/chunky/src/java/se/llbit/chunky/ui/render/tabs/SkyTab.java
@@ -27,7 +27,6 @@ import javafx.geometry.Pos;
 import javafx.scene.Node;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ChoiceBox;
-import javafx.scene.control.ComboBox;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 import javafx.scene.control.TitledPane;
@@ -35,7 +34,6 @@ import javafx.scene.control.Tooltip;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
-import se.llbit.chunky.renderer.scene.FogMode;
 import se.llbit.chunky.renderer.scene.Scene;
 import se.llbit.chunky.renderer.scene.SimulatedSky;
 import se.llbit.chunky.renderer.scene.Sky;
@@ -43,8 +41,6 @@ import se.llbit.chunky.ui.DoubleAdjuster;
 import se.llbit.chunky.ui.elements.GradientEditor;
 import se.llbit.chunky.ui.controller.RenderControlsFxController;
 import se.llbit.chunky.ui.render.RenderControlsTab;
-import se.llbit.chunky.ui.render.settings.LayeredFogSettings;
-import se.llbit.chunky.ui.render.settings.UniformFogSettings;
 import se.llbit.chunky.ui.render.settings.SkyboxSettings;
 import se.llbit.chunky.ui.render.settings.SkymapSettings;
 import se.llbit.fx.LuxColorPicker;
@@ -68,9 +64,6 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
   @FXML private DoubleAdjuster cloudX;
   @FXML private DoubleAdjuster cloudY;
   @FXML private DoubleAdjuster cloudZ;
-  @FXML private ComboBox<FogMode> fogMode;
-  @FXML private TitledPane fogDetailsPane;
-  @FXML private VBox fogDetailsBox;
   private final VBox simulatedSettings = new VBox();
   private DoubleAdjuster horizonOffset = new DoubleAdjuster();
   private ChoiceBox<SimulatedSky> simulatedSky = new ChoiceBox<>();
@@ -79,8 +72,6 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
   private final VBox colorEditor = new VBox(colorPicker);
   private final SkyboxSettings skyboxSettings = new SkyboxSettings();
   private final SkymapSettings skymapSettings = new SkymapSettings();
-  private final UniformFogSettings uniformFogSettings = new UniformFogSettings();
-  private final LayeredFogSettings layeredFogSettings = new LayeredFogSettings();
 
   private ChangeListener<? super javafx.scene.paint.Color> skyColorListener =
       (observable, oldValue, newValue) -> scene.sky().setColor(ColorUtil.fromFx(newValue));
@@ -100,8 +91,6 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     scene = controller.getRenderController().getSceneManager().getScene();
     skyboxSettings.setRenderController(controller.getRenderController());
     skymapSettings.setRenderController(controller.getRenderController());
-    uniformFogSettings.setRenderController(controller.getRenderController());
-    layeredFogSettings.setRenderController(controller.getRenderController());
   }
 
   @Override public void initialize(URL location, ResourceBundle resources) {
@@ -153,26 +142,6 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     cloudZ.setTooltip("Cloud Z offset.");
     cloudZ.setRange(-256, 256);
     cloudZ.onValueChange(value -> scene.sky().setCloudZOffset(value));
-
-    fogMode.getItems().addAll(FogMode.values());
-    fogMode.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-      scene.setFogMode(newValue);
-      switch (newValue) {
-        case NONE: {
-          fogDetailsBox.getChildren().setAll(new Label("Selected mode has no settings."));
-          break;
-        }
-        case UNIFORM: {
-          fogDetailsBox.getChildren().setAll(uniformFogSettings);
-          break;
-        }
-        case LAYERED: {
-          fogDetailsBox.getChildren().setAll(layeredFogSettings);
-          break;
-        }
-      }
-      fogDetailsPane.setExpanded(true);
-    });
 
     skyMode.setTooltip(new Tooltip("Set the type of sky to be used in the scene."));
     skyMode.getItems().addAll(Sky.SkyMode.values());
@@ -232,7 +201,6 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     cloudX.set(scene.sky().cloudXOffset());
     cloudY.set(scene.sky().cloudYOffset());
     cloudZ.set(scene.sky().cloudZOffset());
-    fogMode.getSelectionModel().select(scene.fog.getFogMode());
     horizonOffset.set(scene.sky().getHorizonOffset());
     simulatedSky.setValue(scene.sky().getSimulatedSky());
     gradientEditor.setGradient(scene.sky().getGradient());
@@ -241,12 +209,10 @@ public class SkyTab extends ScrollPane implements RenderControlsTab, Initializab
     colorPicker.colorProperty().addListener(skyColorListener);
     skyboxSettings.update(scene);
     skymapSettings.update(scene);
-    uniformFogSettings.update(scene);
-    layeredFogSettings.update(scene);
   }
 
   @Override public String getTabTitle() {
-    return "Sky & Fog";
+    return "Sky";
   }
 
   @Override public Node getTabContent() {

--- a/chunky/src/java/se/llbit/chunky/world/ExtraMaterials.java
+++ b/chunky/src/java/se/llbit/chunky/world/ExtraMaterials.java
@@ -20,7 +20,6 @@ import se.llbit.chunky.block.minecraft.Candle;
 import se.llbit.chunky.entity.CalibratedSculkSensorAmethyst;
 import se.llbit.chunky.entity.Campfire;
 import se.llbit.chunky.world.material.CloudMaterial;
-import se.llbit.chunky.world.material.ParticleFogMaterial;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +31,6 @@ public class ExtraMaterials {
 
   static {
     idMap.put("cloud", CloudMaterial.INSTANCE);
-    idMap.put("particle_fog", ParticleFogMaterial.INSTANCE);
     idMap.put("candle_flame", Candle.flameMaterial);
     idMap.put("campfire_flame", Campfire.flameMaterial);
     idMap.put("soul_campfire_flame", Campfire.soulFlameMaterial);
@@ -42,7 +40,6 @@ public class ExtraMaterials {
 
   public static void loadDefaultMaterialProperties() {
     CloudMaterial.INSTANCE.restoreDefaults();
-    ParticleFogMaterial.INSTANCE.restoreDefaults();
 
     Candle.flameMaterial.restoreDefaults();
     Candle.flameMaterial.emittance = 1.0f;

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/AdvancedTab.fxml
@@ -25,6 +25,7 @@
     <CheckBox fx:id="shutdown" mnemonicParsing="false" text="Shutdown computer when render completes" />
     <CheckBox fx:id="fastFog" mnemonicParsing="false" text="Fast fog" />
     <CheckBox fx:id="fancierTranslucency" mnemonicParsing="false" text="Fancier translucency" />
+    <CheckBox fx:id="previewParticleFog" mnemonicParsing="false" text="Preview particle fog" />
     <DoubleAdjuster fx:id="transmissivityCap" />
     <IntegerAdjuster fx:id="cacheResolution" />
     <DoubleAdjuster fx:id="animationTime" />

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/FogTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/FogTab.fxml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.ComboBox?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.Separator?>
+<?import javafx.scene.control.TitledPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.ScrollPane?>
+
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.control.TableColumn?>
+<fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
+  <VBox spacing="10.0">
+    <Label text="Fast fog settings" />
+    <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
+      <Label text="Fog mode:" />
+      <ComboBox fx:id="fogMode" prefWidth="150.0" />
+    </HBox>
+    <TitledPane fx:id="fogDetailsPane" animated="false" text="Fog settings">
+      <VBox.margin>
+        <Insets />
+      </VBox.margin>
+      <VBox fx:id="fogDetailsBox" spacing="10.0">
+        <padding>
+          <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+        </padding>
+        <Label text="Selected mode has no settings." />
+      </VBox>
+    </TitledPane>
+    <Separator />
+    <Label text="Particle fog settings" />
+    <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
+      <Button fx:id="addVolume" mnemonicParsing="false" text="Add volume" />
+      <Button fx:id="removeVolume" mnemonicParsing="false" text="Remove volume" />
+    </HBox>
+    <TableView fx:id="fogVolumeTable" prefHeight="120.0">
+      <columns>
+        <TableColumn fx:id="typeCol" text="Volume type" prefWidth="200" />
+      </columns>
+    </TableView>
+    <VBox fx:id="volumeSpecificControls" spacing="10.0" VBox.vgrow="ALWAYS" maxWidth="400"/>
+    <padding>
+      <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+    </padding>
+  </VBox>
+</fx:root>

--- a/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
+++ b/chunky/src/res/se/llbit/chunky/ui/render/tabs/SkyTab.fxml
@@ -3,16 +3,13 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.ChoiceBox?>
-<?import javafx.scene.control.ComboBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.Separator?>
 <?import javafx.scene.control.TitledPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.text.Text?>
 <?import se.llbit.chunky.ui.DoubleAdjuster?>
-<?import se.llbit.fx.LuxColorPicker?>
 
 <fx:root type="javafx.scene.control.ScrollPane" xmlns="http://javafx.com/javafx/8.0.40" xmlns:fx="http://javafx.com/fxml/1">
   <VBox spacing="10.0">
@@ -38,22 +35,6 @@
     <DoubleAdjuster fx:id="cloudX" name="Cloud X" />
     <DoubleAdjuster fx:id="cloudY" name="Cloud Y" />
     <DoubleAdjuster fx:id="cloudZ" name="Cloud Z" />
-    <Separator />
-    <HBox alignment="CENTER_LEFT" prefWidth="200.0" spacing="10.0">
-      <Label text="Fog mode:" />
-      <ComboBox fx:id="fogMode" prefWidth="150.0" />
-    </HBox>
-    <TitledPane fx:id="fogDetailsPane" animated="false" text="Fog settings">
-      <VBox.margin>
-        <Insets />
-      </VBox.margin>
-      <VBox fx:id="fogDetailsBox" spacing="10.0">
-        <padding>
-          <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
-        </padding>
-        <Label text="Selected mode has no settings." />
-      </VBox>
-    </TitledPane>
     <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
     </padding>

--- a/lib/src/se/llbit/chunky/PersistentSettings.java
+++ b/lib/src/se/llbit/chunky/PersistentSettings.java
@@ -656,4 +656,13 @@ public final class PersistentSettings {
     tables.get(table).asObject().set("sort", config);
     save();
   }
+
+  public static void setPreviewParticleFog(boolean value) {
+    settings.setBool("previewParticleFog", value);
+    save();
+  }
+
+  public static boolean getPreviewParticleFog() {
+    return settings.getBool("previewParticleFog", false);
+  }
 }


### PR DESCRIPTION
- Re-enabled use of old (fast) fog.
- Made PathTracer `addSkyFog()` in diffuse reflections.
- Added an option to render particle fog in the render preview to the `Advanced` tab.
- Set the default uniform fog density to 0.05.
- Fixed the sphere implementation.
- Moved all fog controls to a new `Fog` tab.
- Renamed the `Sky & Fog` tab to `Sky`.